### PR TITLE
Add horizontal list example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@
 ## 1.1.29
 * expose getVisibleIndexData method in controller
 
+## 1.1.30
+* Add preferredWidth option
+* Document usage for horizontal scrolling
+
 ## TODO
 * Add horizontal scroll support
 * Add creating items when flutter list view created

--- a/README.md
+++ b/README.md
@@ -65,8 +65,29 @@ FlutterListView(
 ```
 
 If you want better user expierence, preferItemHeight or onItemHeight may set to.
-- preferItemHeight 
-The package don't know the item's height, If you don't set, package alway think the item height is 50 util layout the item. If you know the height, you should set it.  
+- preferItemHeight
+The package don't know the item's height, If you don't set, package alway think the item height is 50 util layout the item. If you know the height, you should set it.
+- preferItemWidth
+The package doesn't know the item's width when scrolling horizontally. If you know it, set preferItemWidth to improve performance.
+- Note: preferItemWidth only hints the layout logic. You still need to provide
+  the actual width of each item in your widget tree.
+- Example for horizontal scrolling:
+```dart
+FlutterListView(
+  scrollDirection: Axis.horizontal,
+  delegate: FlutterListViewDelegate(
+    (context, index) => Container(
+      width: 120,
+      alignment: Alignment.center,
+      margin: const EdgeInsets.symmetric(horizontal: 8),
+      color: Colors.blueAccent,
+      child: Text('Item $index'),
+    ),
+    childCount: 20,
+    preferItemWidth: 120,
+  ),
+)
+```
 - onItemHeight
 like preferItemHeight, the function will used to get height of each item util the item layout.
 ### Keep Position

--- a/example/lib/horizontal_list.dart
+++ b/example/lib/horizontal_list.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_list_view/flutter_list_view.dart';
+
+class HorizontalListExample extends StatelessWidget {
+  const HorizontalListExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Horizontal List')),
+      body: Center(
+        child: SizedBox(
+          height: 120,
+          child: FlutterListView(
+            scrollDirection: Axis.horizontal,
+            delegate: FlutterListViewDelegate(
+              (context, index) => Container(
+                width: 120,
+                alignment: Alignment.center,
+                margin: const EdgeInsets.symmetric(horizontal: 8),
+                color: Colors.blueAccent,
+                child: Text('Item $index'),
+              ),
+              childCount: 20,
+              preferItemWidth: 120,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/route.dart
+++ b/example/lib/route.dart
@@ -18,6 +18,7 @@ import 'jump_to_index.dart';
 import 'list_view_performance.dart';
 import 'permanent_item.dart';
 import 'pull_to_refresh_list.dart';
+import 'horizontal_list.dart';
 import 'separatedList.dart';
 import 'sticky_header.dart';
 import 'sticky_header_refresh.dart';
@@ -65,6 +66,7 @@ class SectionViewRoute {
     "/dynamicContent": (context) => const DynamicContent(),
     "/test1": (context) => const Test1(),
     "/init_jump2": (context) => TestApiWidget(),
-    "/multiple_slivers": (context) => MultipleSlivers()
+    "/multiple_slivers": (context) => MultipleSlivers(),
+    "/horizontal_list": (context) => const HorizontalListExample(),
   };
 }

--- a/lib/src/flutter_list_view_delegate.dart
+++ b/lib/src/flutter_list_view_delegate.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 typedef FlutterListViewDelegateOnItemKey = String Function(int index);
 typedef FlutterListViewDelegateOnItemSticky = bool Function(int index);
 typedef FlutterListViewDelegateOnItemHeight = double Function(int index);
+typedef FlutterListViewDelegateOnItemWidth = double Function(int index);
 
 enum FirstItemAlign { start, end }
 
@@ -31,7 +32,9 @@ class FlutterListViewDelegate extends SliverChildDelegate {
       this.onItemSticky,
       this.stickyAtTailer = false,
       this.onItemHeight,
+      this.onItemWidth,
       this.preferItemHeight = 50,
+      this.preferItemWidth = 50,
       this.firstItemAlign = FirstItemAlign.start,
       this.initIndex = 0,
       this.forceToExecuteInitIndex,
@@ -86,8 +89,15 @@ class FlutterListViewDelegate extends SliverChildDelegate {
   /// It can provide better user expierence
   final FlutterListViewDelegateOnItemHeight? onItemHeight;
 
+  /// If you know the item width when scroll direction is horizontal,
+  /// it is better provider the width for better performance
+  final FlutterListViewDelegateOnItemWidth? onItemWidth;
+
   /// If you didn't provide onItemHeight, the preferItemHeight will be apply to item which is not render.
   final double preferItemHeight;
+
+  /// If you didn't provide onItemWidth, the preferItemWidth will be apply to item which is not render when horizontal scrolling.
+  final double preferItemWidth;
 
   /// Called to build children for the sliver.
   ///

--- a/lib/src/flutter_list_view_element.dart
+++ b/lib/src/flutter_list_view_element.dart
@@ -374,22 +374,30 @@ class FlutterListViewElement extends RenderObjectElement {
     return false;
   }
 
-  /// [_itemHeights]维护着已经layout的高度, 如果_itemHeights有，则取这个高度
-  /// 没有，则返回preferHeight或后面扩展的接口（要用户提供的Height）
+  /// [_itemHeights]维护已知的item主轴尺寸。若已存在直接返回，
+  /// 否则根据滚动方向返回prefer值或回调结果。
   double getItemHeight(String key, int index) {
     if (_itemHeights.containsKey(key)) {
       return _itemHeights[key]!;
-    } else {
-      if (widget.delegate is FlutterListViewDelegate) {
-        var flutterListDelegate = widget.delegate as FlutterListViewDelegate;
+    }
+
+    if (widget.delegate is FlutterListViewDelegate) {
+      var flutterListDelegate = widget.delegate as FlutterListViewDelegate;
+      var axis = renderObject.constraints.axis;
+      if (axis == Axis.horizontal) {
+        if (flutterListDelegate.onItemWidth != null) {
+          return flutterListDelegate.onItemWidth!(index);
+        }
+        return flutterListDelegate.preferItemWidth;
+      } else {
         if (flutterListDelegate.onItemHeight != null) {
           return flutterListDelegate.onItemHeight!(index);
-        } else {
-          return flutterListDelegate.preferItemHeight;
         }
+        return flutterListDelegate.preferItemHeight;
       }
-      return 50.0;
     }
+
+    return 50.0;
   }
 
   bool queryIsStickyItemByIndex(int index) {
@@ -461,7 +469,8 @@ class FlutterListViewElement extends RenderObjectElement {
     if (widget.delegate is FlutterListViewDelegate) {
       var flutterListDelegate = widget.delegate as FlutterListViewDelegate;
       if (flutterListDelegate.onItemKey != null ||
-          flutterListDelegate.onItemHeight != null) {
+          flutterListDelegate.onItemHeight != null ||
+          flutterListDelegate.onItemWidth != null) {
         double height = 0;
         for (var i = 0; i < childCount; i++) {
           height += getItemHeight(getKeyByItemIndex(i), i);
@@ -483,7 +492,12 @@ class FlutterListViewElement extends RenderObjectElement {
       var itemHeight = 50.0;
       if (widget.delegate is FlutterListViewDelegate) {
         var flutterListDelegate = widget.delegate as FlutterListViewDelegate;
-        itemHeight = flutterListDelegate.preferItemHeight;
+        var axis = renderObject.constraints.axis;
+        if (axis == Axis.horizontal) {
+          itemHeight = flutterListDelegate.preferItemWidth;
+        } else {
+          itemHeight = flutterListDelegate.preferItemHeight;
+        }
       }
 
       height += ((childCount - calcItemCount) * itemHeight);

--- a/lib/src/flutter_list_view_render.dart
+++ b/lib/src/flutter_list_view_render.dart
@@ -31,6 +31,10 @@ class FlutterListViewRender extends RenderSliver
   // Visible element
   List<FlutterListViewRenderData> paintedElementsInViewport = [];
 
+  double _mainAxisExtent(Size size) {
+    return constraints.axis == Axis.horizontal ? size.width : size.height;
+  }
+
   @override
   void setupParentData(RenderObject child) {
     if (child.parentData is! SliverMultiBoxAdaptorParentData) {
@@ -184,7 +188,7 @@ class FlutterListViewRender extends RenderSliver
       for (var renderedElement in childManager.renderedElements) {
         var size =
             layoutItem(renderedElement, childConstraints, parentUsesSize: true);
-        var itemHeight = size.height;
+        var itemHeight = _mainAxisExtent(size);
 
         childManager.updateElementPosition2(
           renderedElement,
@@ -204,7 +208,7 @@ class FlutterListViewRender extends RenderSliver
       });
       if (spElement == null) break;
       var size = layoutItem(spElement, childConstraints, parentUsesSize: true);
-      var itemHeight = size.height;
+      var itemHeight = _mainAxisExtent(size);
       var singleCompensationScroll = childManager.updateElementPosition(
           spEle: spElement!,
           newHeight: itemHeight,
@@ -222,7 +226,7 @@ class FlutterListViewRender extends RenderSliver
 
       if (spElement == null) break;
       var size = layoutItem(spElement, childConstraints, parentUsesSize: true);
-      var itemHeight = size.height;
+      var itemHeight = _mainAxisExtent(size);
       childManager.updateElementPosition(
           spEle: spElement!,
           newHeight: itemHeight,
@@ -376,7 +380,7 @@ class FlutterListViewRender extends RenderSliver
         final double mainAxisDelta = childMainAxisPosition(child);
 
         if ((mainAxisDelta < constraints.remainingPaintExtent &&
-                mainAxisDelta + child.size.height > 0) ||
+                mainAxisDelta + _mainAxisExtent(child.size) > 0) ||
             showAllEmenets) {
           if (paintedElements.length > i) {
             var oldPaintedElement = paintedElements[i];
@@ -385,9 +389,9 @@ class FlutterListViewRender extends RenderSliver
                 oldPaintedElement.prevRenderHeight != null &&
                 newPaintedElement != childManager.stickyElement) {
               differIncreaseHeight +=
-                  child.size.height - oldPaintedElement.prevRenderHeight!;
+                  _mainAxisExtent(child.size) - oldPaintedElement.prevRenderHeight!;
               // 位置调整好后，把prevRenderHeight改成新的size, avoid死循环
-              newPaintedElement.prevRenderHeight = child.size.height;
+              newPaintedElement.prevRenderHeight = _mainAxisExtent(child.size);
               if (newPaintedElement.itemKey ==
                   lastPainItemInViewport?.itemKey) {
                 return differIncreaseHeight;
@@ -428,7 +432,7 @@ class FlutterListViewRender extends RenderSliver
 
       var size =
           layoutItem(_jumpToElement, childConstraints, parentUsesSize: true);
-      var itemHeight = size.height;
+      var itemHeight = _mainAxisExtent(size);
 
       childManager.updateElementPosition(
           spEle: _jumpToElement!,
@@ -492,7 +496,7 @@ class FlutterListViewRender extends RenderSliver
 
             var size =
                 layoutItem(chatElem, childConstraints, parentUsesSize: true);
-            var itemHeight = size.height;
+            var itemHeight = _mainAxisExtent(size);
 
             childManager.updateElementPosition(
                 spEle: chatElem,
@@ -697,7 +701,7 @@ class FlutterListViewRender extends RenderSliver
 
         var size = layoutItem(prevStickyElement, childConstraints,
             parentUsesSize: true);
-        var itemHeight = size.height;
+        var itemHeight = _mainAxisExtent(size);
 
         childManager.updateElementPosition(
             spEle: prevStickyElement!,
@@ -849,13 +853,13 @@ class FlutterListViewRender extends RenderSliver
               growInfo.crossAxisUnit.dy * crossAxisDelta,
         );
         if (growInfo.addExtent) {
-          childOffset += growInfo.mainAxisUnit * child.size.height;
+          childOffset += growInfo.mainAxisUnit * _mainAxisExtent(child.size);
         }
 
         // If the child's visible interval (mainAxisDelta, mainAxisDelta + paintExtentOf(child))
         // does not intersect the paint extent interval (0, constraints.remainingPaintExtent), it's hidden.
         if ((mainAxisDelta < constraints.remainingPaintExtent &&
-                mainAxisDelta + child.size.height > 0) ||
+                mainAxisDelta + _mainAxisExtent(child.size) > 0) ||
             showAllEmenets) {
           if (firstPainItemInViewport == null) {
             firstPainItemInViewport = renderElement;
@@ -867,22 +871,22 @@ class FlutterListViewRender extends RenderSliver
           }
 
           if (mainAxisDelta < constraints.remainingPaintExtent &&
-              mainAxisDelta + child.size.height >=
+              mainAxisDelta + _mainAxisExtent(child.size) >=
                   constraints.remainingPaintExtent) {
             if (lastPainItemInViewport == null) {
               lastPainItemInViewport = renderElement;
               lastPainItemOffsetY = renderElement.offset;
-              lastPainItemHeight = child.size.height;
-            }
+              lastPainItemHeight = _mainAxisExtent(child.size);
+          }
           }
 
           // remember last render height
-          renderElement.prevRenderHeight = child.size.height;
+          renderElement.prevRenderHeight = _mainAxisExtent(child.size);
 
           paintElements.add(FlutterListViewItemPosition(
               index: renderElement.index,
               offset: childOffset.dy,
-              height: child.size.height));
+              height: _mainAxisExtent(child.size)));
           if (renderElement != childManager.stickyElement) {
             paintItem(context, child, childOffset);
             paintedElements.add(renderElement);
@@ -915,22 +919,22 @@ class FlutterListViewRender extends RenderSliver
           childManager.stickyElement!.element.renderObject as RenderBox?;
       if (stickyRenderObj != null && stickyRenderObj.parent == this) {
         if (nextStickyOffset == null ||
-            nextStickyOffset.dy > stickyRenderObj.size.height) {
+            nextStickyOffset.dy > _mainAxisExtent(stickyRenderObj.size)) {
           var stickyOffsetDy = offset.dy;
 
           if (growInfo.axisDirection == AxisDirection.up) {
             stickyOffsetDy = offset.dy +
                 constraints.viewportMainAxisExtent -
-                stickyRenderObj.size.height;
+                _mainAxisExtent(stickyRenderObj.size);
           }
           var childOffset = Offset(offset.dx, stickyOffsetDy);
           paintItem(context, stickyRenderObj, childOffset);
         } else {
           var stickyOffsetDy =
-              nextStickyOffset.dy - stickyRenderObj.size.height;
+              nextStickyOffset.dy - _mainAxisExtent(stickyRenderObj.size);
           if (growInfo.axisDirection == AxisDirection.up) {
             stickyOffsetDy = constraints.viewportMainAxisExtent -
-                stickyRenderObj.size.height -
+                _mainAxisExtent(stickyRenderObj.size) -
                 stickyOffsetDy;
           }
           var childOffset = Offset(0, stickyOffsetDy);
@@ -950,10 +954,10 @@ class FlutterListViewRender extends RenderSliver
         if (nextStickyOffset == null ||
             nextStickyOffset.dy + _trackedNextStickyElement!.height <
                 constraints.viewportMainAxisExtent -
-                    stickyRenderObj.size.height) {
+                    _mainAxisExtent(stickyRenderObj.size)) {
           var stickyOffsetDy = offset.dy +
               constraints.viewportMainAxisExtent -
-              stickyRenderObj.size.height;
+              _mainAxisExtent(stickyRenderObj.size);
 
           if (growInfo.axisDirection == AxisDirection.up) {
             stickyOffsetDy = offset.dy;
@@ -967,7 +971,7 @@ class FlutterListViewRender extends RenderSliver
             stickyOffsetDy = constraints.viewportMainAxisExtent -
                 nextStickyOffset.dy -
                 _trackedNextStickyElement!.height -
-                stickyRenderObj.size.height;
+                _mainAxisExtent(stickyRenderObj.size);
           }
           var childOffset = Offset(0, stickyOffsetDy);
           paintItem(context, stickyRenderObj, childOffset);
@@ -1151,8 +1155,8 @@ class FlutterListViewRender extends RenderSliver
         break;
       case Axis.vertical:
         if (!rightWayUp) {
-          absolutePosition = child.size.height - absolutePosition;
-          delta = geometry!.paintExtent - child.size.height - delta;
+          absolutePosition = _mainAxisExtent(child.size) - absolutePosition;
+          delta = geometry!.paintExtent - _mainAxisExtent(child.size) - delta;
         }
         paintOffset = Offset(crossAxisDelta, delta);
         transformedPosition =
@@ -1206,7 +1210,7 @@ class FlutterListViewRender extends RenderSliver
         break;
       case Axis.vertical:
         if (!rightWayUp) {
-          delta = geometry!.paintExtent - child.size.height - delta;
+          delta = geometry!.paintExtent - _mainAxisExtent(child.size) - delta;
         }
         transform.translate(crossAxisDelta, delta);
         break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_list_view
 description: Provide enhanced list view include jump index, keep position etc.
-version: 1.1.29
+version: 1.1.30
 homepage: https://github.com/robert-luoqing/flutter_list_view
 
 environment:


### PR DESCRIPTION
## Summary
- clarify that `preferItemWidth` only hints layout and show example
- add horizontal list example in `example` app
- update changelog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521bffb2a0832982c8a696a8e63e59