### PR TITLE
Expose anchor to builder and separated constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ FlutterListView(
     childCount: data.length,
   ))
 ```
+To center a specific item when the list is taller than the viewport, provide
+`anchor: 0.5` and an `initIndex` on the delegate so that the selected item
+starts in the middle:
+```dart
+FlutterListView(
+  anchor: 0.5,
+  delegate: FlutterListViewDelegate(
+    (context, index) => ListTile(title: Text('Item $index')),
+    childCount: data.length,
+    initIndex: 0, // or any index you want centered
+  ),
+)
+```
 ### Jump to index
 ```dart
 flutterListViewController.jumpToIndex(100);

--- a/lib/src/flutter_list_view.dart
+++ b/lib/src/flutter_list_view.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 class FlutterListView extends CustomScrollView {
   final SliverChildDelegate delegate;
   final FlutterListViewController? _controller;
+  final double anchor;
 
   const FlutterListView({
     Key? key,
@@ -19,7 +20,7 @@ class FlutterListView extends CustomScrollView {
     ScrollBehavior? scrollBehavior,
     bool shrinkWrap = false,
     Key? center,
-    double anchor = 0.0,
+    this.anchor = 0.0,
     double? cacheExtent,
     int? semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
@@ -54,6 +55,7 @@ class FlutterListView extends CustomScrollView {
     bool? primary,
     ScrollPhysics? physics,
     bool shrinkWrap = false,
+    this.anchor = 0.0,
     // EdgeInsetsGeometry? padding,
     required IndexedWidgetBuilder itemBuilder,
     int? itemCount,
@@ -89,6 +91,7 @@ class FlutterListView extends CustomScrollView {
           dragStartBehavior: dragStartBehavior,
           keyboardDismissBehavior: keyboardDismissBehavior,
           restorationId: restorationId,
+          anchor: anchor,
           clipBehavior: clipBehavior,
         );
 
@@ -100,6 +103,7 @@ class FlutterListView extends CustomScrollView {
     bool? primary,
     ScrollPhysics? physics,
     bool shrinkWrap = false,
+    this.anchor = 0.0,
     // EdgeInsetsGeometry? padding,
     required IndexedWidgetBuilder itemBuilder,
     required IndexedWidgetBuilder separatorBuilder,
@@ -153,6 +157,7 @@ class FlutterListView extends CustomScrollView {
           dragStartBehavior: dragStartBehavior,
           keyboardDismissBehavior: keyboardDismissBehavior,
           restorationId: restorationId,
+          anchor: anchor,
           clipBehavior: clipBehavior,
         );
 
@@ -162,6 +167,7 @@ class FlutterListView extends CustomScrollView {
       FlutterSliverList(
         delegate: delegate,
         controller: _controller?.sliverController,
+        anchor: anchor,
       )
     ];
   }

--- a/lib/src/flutter_list_view_render.dart
+++ b/lib/src/flutter_list_view_render.dart
@@ -8,9 +8,17 @@ class FlutterListViewRender extends RenderSliver
     with RenderSliverWithKeepAliveMixin, RenderSliverHelpers {
   FlutterListViewRender({
     required this.childManager,
-  });
+    double anchor = 0.0,
+  }) : _anchor = anchor;
 
   final FlutterListViewElement childManager;
+  double _anchor;
+  double get anchor => _anchor;
+  set anchor(double value) {
+    if (_anchor == value) return;
+    _anchor = value;
+    markNeedsLayout();
+  }
 
   /// Remember the first paint item in viewport
   /// We will use the data to keep position if some items
@@ -443,11 +451,14 @@ class FlutterListViewRender extends RenderSliver
           ? indexShoudBeJumpOffset * viewportExtent
           : indexShoudBeJumpOffset;
 
-      var scrollDy = itemDy - offsetPx;
-      _jumpDistanceFromTop = offsetPx;
+      var anchorOffset = anchor * viewportExtent;
+      var scrollDy = itemDy - offsetPx - anchorOffset;
+      _jumpDistanceFromTop = offsetPx + anchorOffset;
       if (offsetBasedOnBottom) {
-        scrollDy = itemDy - (viewportExtent - (offsetPx + itemHeight));
-        _jumpDistanceFromTop = viewportExtent - (offsetPx + itemHeight);
+        scrollDy =
+            itemDy - (viewportExtent - (offsetPx + itemHeight)) - anchorOffset;
+        _jumpDistanceFromTop =
+            viewportExtent - (offsetPx + itemHeight) + anchorOffset;
       }
 
       if (scrollDy < 0) scrollDy = 0;

--- a/lib/src/flutter_sliver_list.dart
+++ b/lib/src/flutter_sliver_list.dart
@@ -6,11 +6,16 @@ import 'flutter_list_view_render.dart';
 
 class FlutterSliverList extends SliverWithKeepAliveWidget {
   /// Creates a sliver that places box children in a linear array.
-  const FlutterSliverList({Key? key, required this.delegate, this.controller})
-      : super(key: key);
+  const FlutterSliverList({
+    Key? key,
+    required this.delegate,
+    this.controller,
+    this.anchor = 0.0,
+  }) : super(key: key);
 
   final SliverChildDelegate delegate;
   final FlutterSliverListController? controller;
+  final double anchor;
 
   @override
   FlutterListViewElement createElement() => FlutterListViewElement(this);
@@ -19,6 +24,12 @@ class FlutterSliverList extends SliverWithKeepAliveWidget {
   FlutterListViewRender createRenderObject(BuildContext context) {
     final FlutterListViewElement element = context as FlutterListViewElement;
 
-    return FlutterListViewRender(childManager: element);
+    return FlutterListViewRender(childManager: element, anchor: anchor);
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, FlutterListViewRender renderObject) {
+    renderObject.anchor = anchor;
   }
 }


### PR DESCRIPTION
## Summary
- expose the `anchor` parameter on `FlutterListView.builder` and `FlutterListView.separated`
- document how to center the first item using `anchor: 0.5`
- ensure `initIndex` respects the `anchor` offset when jumping to an item

## Testing
- `flutter format lib/src/flutter_list_view.dart lib/src/flutter_sliver_list.dart lib/src/flutter_list_view_render.dart README.md` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854c5b98b908329a1f08f40fcd2a98d