### PR TITLE
Expose anchor to builder and separated constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ FlutterListView(
     childCount: data.length,
   ))
 ```
+To center the first item when the list is taller than the viewport, provide
+`anchor: 0.5`:
+```dart
+FlutterListView(
+  anchor: 0.5,
+  delegate: FlutterListViewDelegate(
+    (context, index) => ListTile(title: Text('Item $index')),
+    childCount: data.length,
+  ),
+)
+```
+You can also specify which item starts at the anchor using `initIndex`. The
+builder constructors default the initial offset to the provided `anchor`:
+```dart
+FlutterListView.builder(
+  anchor: 0.5,
+  initIndex: 10,
+  itemBuilder: (context, index) => ListTile(title: Text('Item $index')),
+  itemCount: data.length,
+)
+```
 ### Jump to index
 ```dart
 flutterListViewController.jumpToIndex(100);

--- a/lib/src/flutter_list_view.dart
+++ b/lib/src/flutter_list_view.dart
@@ -54,6 +54,11 @@ class FlutterListView extends CustomScrollView {
     bool? primary,
     ScrollPhysics? physics,
     bool shrinkWrap = false,
+    double anchor = 0.0,
+    int initIndex = 0,
+    double? initOffset,
+    bool initOffsetBasedOnBottom = false,
+    FirstItemAlign firstItemAlign = FirstItemAlign.start,
     // EdgeInsetsGeometry? padding,
     required IndexedWidgetBuilder itemBuilder,
     int? itemCount,
@@ -68,12 +73,16 @@ class FlutterListView extends CustomScrollView {
     String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
   })  : _controller = controller,
-        delegate = SliverChildBuilderDelegate(
+        delegate = FlutterListViewDelegate(
           itemBuilder,
           childCount: itemCount,
           addAutomaticKeepAlives: addAutomaticKeepAlives,
           addRepaintBoundaries: addRepaintBoundaries,
           addSemanticIndexes: addSemanticIndexes,
+          initIndex: initIndex,
+          initOffset: initOffset ?? anchor,
+          initOffsetBasedOnBottom: initOffsetBasedOnBottom,
+          firstItemAlign: firstItemAlign,
         ),
         super(
           key: key,
@@ -89,6 +98,7 @@ class FlutterListView extends CustomScrollView {
           dragStartBehavior: dragStartBehavior,
           keyboardDismissBehavior: keyboardDismissBehavior,
           restorationId: restorationId,
+          anchor: anchor,
           clipBehavior: clipBehavior,
         );
 
@@ -100,6 +110,11 @@ class FlutterListView extends CustomScrollView {
     bool? primary,
     ScrollPhysics? physics,
     bool shrinkWrap = false,
+    double anchor = 0.0,
+    int initIndex = 0,
+    double? initOffset,
+    bool initOffsetBasedOnBottom = false,
+    FirstItemAlign firstItemAlign = FirstItemAlign.start,
     // EdgeInsetsGeometry? padding,
     required IndexedWidgetBuilder itemBuilder,
     required IndexedWidgetBuilder separatorBuilder,
@@ -114,7 +129,7 @@ class FlutterListView extends CustomScrollView {
     String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
   })  : _controller = controller,
-        delegate = SliverChildBuilderDelegate(
+        delegate = FlutterListViewDelegate(
           (BuildContext context, int index) {
             final int itemIndex = index ~/ 2;
             final Widget widget;
@@ -138,6 +153,10 @@ class FlutterListView extends CustomScrollView {
           semanticIndexCallback: (Widget _, int index) {
             return index.isEven ? index ~/ 2 : null;
           },
+          initIndex: initIndex,
+          initOffset: initOffset ?? anchor,
+          initOffsetBasedOnBottom: initOffsetBasedOnBottom,
+          firstItemAlign: firstItemAlign,
         ),
         super(
           key: key,
@@ -153,6 +172,7 @@ class FlutterListView extends CustomScrollView {
           dragStartBehavior: dragStartBehavior,
           keyboardDismissBehavior: keyboardDismissBehavior,
           restorationId: restorationId,
+          anchor: anchor,
           clipBehavior: clipBehavior,
         );
 


### PR DESCRIPTION
## Summary
- expose the `anchor` parameter on `FlutterListView.builder` and `.separated`
- support centering any `initIndex` by defaulting `initOffset` to `anchor`
- update documentation with an example using `initIndex`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c5b98b908329a1f08f40fcd2a98d